### PR TITLE
Customize Git operations and a checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ A simple GitHub Action to enforce CRLF on selected file types in your repo.
 
 Example worflow:
 ```yml
-name: Enforce-CRLF
+name: Force CRLF for files inside the index
 
 on:
   push:
@@ -18,7 +18,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Enforce CRLF action
-      uses: DecimalTurn/Enforce-CRLF@v1
+      uses: DecimalTurn/Enforce-CRLF@main
       with:
         extensions: .bas, .frm, .cls
+        do-checkout: true
+        do-push: true
+```
+
+Note that in the above example, we are setting `do-checkout` and `do-push` in order to let Enforce-CRLF perform those steps for us. If however, you want Enforce-CRLF to be part of a more complex workflow where you've already performed the `git checkout` and/or will perform the `git push` at the end, you can always set those values to false.
+
+```yml
+        do-checkout: false
+        do-push: false
 ```

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,12 @@ inputs:
   extensions:
     description: 'List of extensions (including the dot) seperated by a comma.'
     required: true
+  do-checkout:
+    description: 'Set to true in order to let the action perform the checkout for you (default = false).'
+    default: false    
+  do-push:
+    description: 'Set to true in order to let the action perform the checkout for you (default = false).'
+    default: false
   bot-name:
     description: 'Name of the bot that will perform the commit.'
     default: 'github-actions[bot]'
@@ -16,7 +22,13 @@ inputs:
 runs:
   using: "composite"
   steps:
+  - name: Configure Git
+    if: ${{ inputs.do-checkout }}
+    run: |
+      git config --global core.autocrlf false
+      git config --global core.eol lf
   - name: Checkout
+    if: ${{ inputs.do-checkout() }}
     uses: actions/checkout@v4
   - name: Set up Python 3.10
     uses: actions/setup-python@v5
@@ -32,6 +44,7 @@ runs:
       python '${{ github.action_path }}/enforce-crlf.py' "${{ inputs.extensions }}"
     shell: bash
   - name: Push content
+    if: ${{ inputs.do-push }}
     uses: stefanzweifel/git-auto-commit-action@v5
     with:
       # Optional. Commit message for the created commit.

--- a/action.yml
+++ b/action.yml
@@ -32,14 +32,14 @@ runs:
     uses: actions/checkout@v4
   - name: Check EOL configs
     run: |
-    IFS=',' read -r -a ext_array <<< "${{ inputs.extensions }}"
-    for ext in "${ext_array[@]}"; do
-      result=$(git check-attr eol *"${ext}")
-      if [[ $result == *"text: auto" || $result == *"text: text" ]]; then
-        echo "There is an issue with ${ext}"
-        exit 1
-      fi
-    done
+      IFS=',' read -r -a ext_array <<< "${{ inputs.extensions }}"
+      for ext in "${ext_array[@]}"; do
+        result=$(git check-attr eol *"${ext}")
+        if [[ $result == *"text: auto" || $result == *"text: text" ]]; then
+          echo "There is an issue with ${ext}"
+          exit 1
+        fi
+      done
     shell: bash
   - name: Set up Python 3.10
     uses: actions/setup-python@v5

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,9 @@ runs:
       git config --global core.autocrlf false
       git config --global core.eol lf
     shell: bash
+  - name: Checkout
+    if: ${{ inputs.do-checkout }}
+    uses: actions/checkout@v4
   - name: Check EOL configs
     run: |
       IFS=',' read -r -a ext_array <<< "${{ inputs.extensions }}"
@@ -34,9 +37,6 @@ runs:
         git check-attr eol *"${ext}"
       done
     shell: bash
-  - name: Checkout
-    if: ${{ inputs.do-checkout }}
-    uses: actions/checkout@v4
   - name: Set up Python 3.10
     uses: actions/setup-python@v5
     with:

--- a/action.yml
+++ b/action.yml
@@ -32,10 +32,14 @@ runs:
     uses: actions/checkout@v4
   - name: Check EOL configs
     run: |
-      IFS=',' read -r -a ext_array <<< "${{ inputs.extensions }}"
-      for ext in "${ext_array[@]}"; do
-        git check-attr text *"${ext}"
-      done
+    IFS=',' read -r -a ext_array <<< "${{ inputs.extensions }}"
+    for ext in "${ext_array[@]}"; do
+      result=$(git check-attr eol *"${ext}")
+      if [[ $result == *"text: auto" || $result == *"text: text" ]]; then
+        echo "There is an issue with ${ext}"
+        exit 1
+      fi
+    done
     shell: bash
   - name: Set up Python 3.10
     uses: actions/setup-python@v5

--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,8 @@ runs:
     run: |
       IFS=',' read -r -a ext_array <<< "${{ inputs.extensions }}"
       for ext in "${ext_array[@]}"; do
-        result=$(git check-attr eol *"${ext}")
+        result=$(git check-attr text *"${ext}")
+        echo "$result"
         if [[ $result == *"text: auto" || $result == *"text: text" ]]; then
           echo "There is an issue with ${ext}"
           exit 1

--- a/action.yml
+++ b/action.yml
@@ -23,10 +23,16 @@ runs:
   using: "composite"
   steps:
   - name: Configure Git
-    if: ${{ inputs.do-checkout }}
     run: |
       git config --global core.autocrlf false
       git config --global core.eol lf
+    shell: bash
+  - name: Check EOL configs
+    run: |
+      IFS=',' read -r -a ext_array <<< "${{ inputs.extensions }}"
+      for ext in "${ext_array[@]}"; do
+        git check-attr eol *"${ext}"
+      done
     shell: bash
   - name: Checkout
     if: ${{ inputs.do-checkout }}

--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ runs:
     run: |
       IFS=',' read -r -a ext_array <<< "${{ inputs.extensions }}"
       for ext in "${ext_array[@]}"; do
-        git check-attr eol *"${ext}"
+        git check-attr text *"${ext}"
       done
     shell: bash
   - name: Set up Python 3.10

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,7 @@ runs:
     run: |
       git config --global core.autocrlf false
       git config --global core.eol lf
+    shell: bash
   - name: Checkout
     if: ${{ inputs.do-checkout }}
     uses: actions/checkout@v4

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ runs:
       git config --global core.autocrlf false
       git config --global core.eol lf
   - name: Checkout
-    if: ${{ inputs.do-checkout() }}
+    if: ${{ inputs.do-checkout }}
     uses: actions/checkout@v4
   - name: Set up Python 3.10
     uses: actions/setup-python@v5

--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,8 @@ runs:
         result=$(git check-attr text *"${ext}")
         echo "$result"
         if [[ $result == *"text: auto" || $result == *"text: text" ]]; then
-          echo "There is an issue with ${ext}"
+          echo "There is an issue with the ${ext} extension. The `text` attribute is set or it has a value of `auto` for that extension."
+          echo "This means that you won't be able to commit changes with CRLF. You need to make sure that `text` is unspecified or unset (-text)"
           exit 1
         fi
       done


### PR DESCRIPTION
Changes:
* Include `do-checkout` and `do-push` (false by default) to allow for easier integration in existing worflows.
* Add step to check .gitattributes file for problematic configurations that would prevent CRLF conversion.