### PR TITLE
Support fail-on-lf option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,19 @@ jobs:
 Note that in the above example, we are setting `do-checkout` and `do-push` in order to let Enforce-CRLF perform those steps for us. If however, you want Enforce-CRLF to be part of a more complex workflow where you've already performed the `git checkout` and/or will perform the `git push` at the end, you can always set those values to false.
 
 ```yml
+      with:
+        extensions: .bas, .frm, .cls
         do-checkout: false
         do-push: false
 ```
+
+If you want the workflow to fail (and not auto-fix) when files with LF endings are found, set `fail-on-lf: true`:
+
+```yml
+      with:
+        extensions: .bas, .frm, .cls
+        do-checkout: true
+        fail-on-lf: true
+```
+
+When `fail-on-lf` is enabled, the action will check for files needing CRLF conversion and fail the workflow if any are found, without modifying them. This is useful to get alerted if a PR introduces LF line endings in files that should be CRLF, but it doesn't require the action to modify the files, so you don't need to give it write permissions.

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,10 @@ inputs:
   extensions:
     description: 'List of extensions (including the dot) seperated by a comma.'
     required: true
+  fail-on-lf:
+    description: 'If true, fail the workflow if any files need to be converted (do not auto-fix, just report and fail).'
+    required: false
+    default: false
   do-checkout:
     description: 'Set to true in order to let the action perform the checkout for you (default = false).'
     default: false    
@@ -19,6 +23,7 @@ inputs:
   bot-email:
     description: 'Email of the bot that will perform the commit.'
     default: '41898282+github-actions[bot]@users.noreply.github.com'
+
 runs:
   using: "composite"
   steps:
@@ -78,7 +83,7 @@ runs:
       version: 1.0
   - name: Run script
     run: |
-      python '${{ github.action_path }}/enforce_crlf.py' "${{ inputs.extensions }}"
+      python '${{ github.action_path }}/enforce_crlf.py' --extensions "${{ inputs.extensions }}" --fail-on-lf "${{ inputs.fail-on-lf }}"
     shell: bash
   - name: Push content
     if: ${{ inputs.do-push }}


### PR DESCRIPTION
This pull request introduces a new feature to the Enforce-CRLF GitHub Action, allowing workflows to fail when files with LF line endings are detected, without automatically fixing them. 

### Feature Addition: Fail on LF Line Endings
* **`action.yml`:** Added a new input parameter `fail-on-lf` with a default value of `false`. This input allows users to configure the action to fail the workflow if files require CRLF conversion, without modifying the files.
* **`enforce_crlf.py`:** Updated the script to include logic for handling the `fail-on-lf` parameter. If enabled, the script identifies files needing conversion, logs them, and exits with a non-zero status to fail the workflow. 

### Documentation Update
* **`README.md`:** Added examples and explanations for using the new `fail-on-lf` parameter, including its benefits and use cases.

### Refactoring for Command-Line Arguments
* **`enforce_crlf.py`:** Refactored the script to use named arguments (`--extensions` and `--fail-on-lf`) instead of positional arguments for better clarity and extensibility. 

### Workflow Script Update
* **`action.yml`:** Updated the command used to invoke the script to include the new `--fail-on-lf` argument.